### PR TITLE
Adversarial input, and the three things it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   # Leak detection is off for now. The engine allocates its pools once and
   # does not always hand them back, so turning it on today would report the
   # design rather than a bug. Worth a separate pass.
-  sanitizers:
+  sanitisers:
     runs-on: ubuntu-latest
     env:
       ASAN_OPTIONS: detect_leaks=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,24 @@ jobs:
       - name: Score
         run: bash tools/sv-tests.sh /tmp/sv-tests --min 66
 
+  # Hostile input through instrumentation. The adv suite feeds in binary junk,
+  # two-thousand-deep nesting and pools shrunk to eight, which is only worth
+  # running if something is watching the memory while it happens.
+  #
+  # Leak detection is off for now. The engine allocates its pools once and
+  # does not always hand them back, so turning it on today would report the
+  # design rather than a bug. Worth a separate pass.
+  sanitizers:
+    runs-on: ubuntu-latest
+    env:
+      ASAN_OPTIONS: detect_leaks=0
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test under ASan and UBSan
+        run: make SAN=1 CC=clang test
+
   build-windows:
     runs-on: windows-latest
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ list.txt
 
 # Header dependency files from -MMD
 *.d
+
+# Planning scratch
+kplt.txt

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,25 @@
 CHANGELOG
 =========
 
+2026-08-17  Adversarial input, and the three things it found
+  - tests/tadv.c, nine tests that ask what happens at a bound. The
+    pools are runtime fields as well as constants, so a test shrinks
+    max_tok to eight rather than generating two megabytes of source.
+    That is why these paths had never run.
+  - All three lexers bounded the main loop with TK_MAX_TOKENS while
+    iterating over characters, so a 2MB source stopped two thirds of
+    the way through and returned success. Bounded by source length
+    now, and anything left over is TK006.
+  - Token, string and AST pools all filled quietly. TK005, TK007 and
+    TK004 say so instead, and ab_parse capped against the constant
+    rather than the field so that path could not be tested at all.
+  - sa_luby called itself, which the house rules ban, and its
+    reduction loop had no stop condition. Iterative and bounded now,
+    checked against Knuth's prefix and the old function to 200000.
+  - clang had never built the tree, thanks to a gcc-only pragma in
+    tk_vlog.c. A sanitiser job builds with it under ASan and UBSan.
+  - The runner printed PASS under every FAIL.
+
 2026-08-10  JEDEC fuse maps, a 74LS target, and an emitter that meant it
   - jd_read parses JESD3-C, the format PLD programmers write. Fuse
     states only. Both checksums are compared, and a mismatch is

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,15 @@ CFLAGS = $(WARN) -std=c99 -O0 -g -DDEBUG -MMD -MP $(INCS)
 TFLAGS = $(WARN) -std=c99 -O0 -g -DDEBUG -MMD -MP $(INCS)
 endif
 
+# make SAN=1 builds under ASan and UBSan. The adversarial tests are why this
+# exists: junk bytes, two-thousand-deep nesting and pools shrunk to eight are
+# only worth running if something is watching the memory while they run.
+ifdef SAN
+SANF    = -fsanitize=address,undefined -fno-omit-frame-pointer -g -O1
+CFLAGS += $(SANF)
+TFLAGS += $(SANF)
+endif
+
 # Source files -- one line per stage
 SRCS = src/main.c \
        src/tk_abend.c \

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ TEST_SRCS = tests/tmain.c tests/tlex.c tests/tparse.c tests/telab.c \
             tests/trtl.c tests/topt.c tests/tmap.c tests/tvhdl.c \
             tests/tabel.c tests/thash.c tests/tspans.c tests/tmmap.c \
             tests/tlfn.c tests/tnlst.c tests/tsat.c tests/tfi.c \
-            tests/tjed.c
+            tests/tjed.c tests/tadv.c
 TEST_TARGET = trunner
 
 ifeq ($(OS),Windows_NT)

--- a/include/takahe.h
+++ b/include/takahe.h
@@ -178,6 +178,7 @@ typedef struct {
     /* Errors */
     uint32_t      n_err;
     uint8_t       tok_ovf;   /* token pool filled, source truncated */
+    uint8_t       str_ovf;   /* string pool filled, names came back empty */
 } tk_lex_t;
 
 /* ---- Error Entry ---- */
@@ -452,6 +453,7 @@ typedef struct {
     /* Errors */
     tk_err_t          errors[TK_MAX_ERRORS];
     uint32_t          n_err;
+    uint8_t           node_ovf;  /* AST pool filled, tree is incomplete */
 } tk_parse_t;
 
 /* ---- Public API ---- */

--- a/lang/en.txt
+++ b/lang/en.txt
@@ -11,6 +11,7 @@ TK003 parse error at %u:%u: %s
 TK004 AST node pool exhausted (%u nodes)
 TK005 token pool exhausted (%u tokens, max %u)
 TK006 lexer stopped at byte %u of %u
+TK007 string pool exhausted (%u bytes, max %u)
 
 # ---- Elaboration (010-019) ----
 TK010 unresolved parameter '%s'

--- a/src/emit/tk_vlog.c
+++ b/src/emit/tk_vlog.c
@@ -191,8 +191,12 @@ em_busbit(const rt_mod_t *M, uint32_t ni, char *base,
 /* ---- Emit a net reference in a cell connection ----
  * Bus port bits emit as base[N] rather than base_N */
 
+/* -Wformat-truncation is a gcc warning group and clang errors on the name
+ * under -Werror, so the pragma has to be hidden from it. */
+#ifndef __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 static const char *
 em_cnet(const rt_mod_t *M, uint32_t ni, char *buf, int bsz)
 {
@@ -205,7 +209,9 @@ em_cnet(const rt_mod_t *M, uint32_t ni, char *buf, int bsz)
     }
     return em_nnam(M, ni, buf, bsz);
 }
+#ifndef __clang__
 #pragma GCC diagnostic pop
+#endif
 
 /* ---- Cell input: inline constants ----
  * If net ni is driven by a CONST cell, return "1'b0"/"1'b1".

--- a/src/lex/ab_lex.c
+++ b/src/lex/ab_lex.c
@@ -81,7 +81,14 @@ static uint32_t
 ab_sint(tk_lex_t *L, const char *s, uint16_t len)
 {
     uint32_t off;
-    if (L->str_len + len + 1 > L->str_max) return 0;
+    if (L->str_len + len + 1 > L->str_max) {
+        if (!L->str_ovf) {
+            L->str_ovf = 1;
+            L->n_err++;
+            tk_emsg(7, L->str_len, L->str_max);
+        }
+        return 0;                 /* offset 0 is the reserved empty string */
+    }
     off = L->str_len;
     memcpy(L->strs + off, s, len);
     L->strs[off + len] = '\0';
@@ -158,6 +165,7 @@ ab_lex(tk_lex_t *L, const char *src, uint32_t len)
     L->n_tok   = 0;
     L->n_err   = 0;
     L->tok_ovf = 0;
+    L->str_ovf = 0;
 
     /* Bounded by the source length, because every path through the body
      * advances pos by at least one. Sizing it in tokens was wrong, since

--- a/src/lex/tk_lex.c
+++ b/src/lex/tk_lex.c
@@ -72,7 +72,14 @@ lx_sint(tk_lex_t *L, const char *s, uint16_t len)
 {
     uint32_t off;
 
-    if (L->str_len + len + 1 > L->str_max) return 0;
+    if (L->str_len + len + 1 > L->str_max) {
+        if (!L->str_ovf) {
+            L->str_ovf = 1;
+            L->n_err++;
+            tk_emsg(7, L->str_len, L->str_max);
+        }
+        return 0;                 /* offset 0 is the reserved empty string */
+    }
 
     off = L->str_len;
     memcpy(L->strs + off, s, len);
@@ -147,6 +154,7 @@ tk_lex(tk_lex_t *L, const char *src, uint32_t len)
     L->n_tok   = 0;
     L->n_err   = 0;
     L->tok_ovf = 0;
+    L->str_ovf = 0;
 
     /* Bounded by the source length, because every path through the body
      * advances pos by at least one. Sizing it in tokens was wrong, since

--- a/src/lex/vh_lex.c
+++ b/src/lex/vh_lex.c
@@ -51,7 +51,14 @@ vh_sint(tk_lex_t *L, const char *s, uint16_t len, int do_lower)
 {
     uint32_t off;
 
-    if (L->str_len + len + 1 > L->str_max) return 0;
+    if (L->str_len + len + 1 > L->str_max) {
+        if (!L->str_ovf) {
+            L->str_ovf = 1;
+            L->n_err++;
+            tk_emsg(7, L->str_len, L->str_max);
+        }
+        return 0;                 /* offset 0 is the reserved empty string */
+    }
 
     off = L->str_len;
     if (do_lower) {
@@ -162,6 +169,7 @@ vh_lex(tk_lex_t *L, const char *src, uint32_t len)
     L->n_tok   = 0;
     L->n_err   = 0;
     L->tok_ovf = 0;
+    L->str_ovf = 0;
 
     /* Bounded by the source length, because every path through the body
      * advances pos by at least one. Sizing it in tokens was wrong, since

--- a/src/parse/ab_parse.c
+++ b/src/parse/ab_parse.c
@@ -123,7 +123,14 @@ ab_node(ab_ctx_t *C, tk_ast_type_t type, uint32_t tok_idx)
     uint32_t ni;
     const tk_token_t *t;
 
-    if (P->n_node >= TK_MAX_NODES) return 0;
+    if (P->n_node >= P->max_node) {
+        if (!P->node_ovf) {
+            P->node_ovf = 1;
+            P->n_err++;
+            tk_emsg(4, P->max_node);
+        }
+        return 0;
+    }
 
     ni = P->n_node++;
     memset(&P->nodes[ni], 0, sizeof(P->nodes[ni]));

--- a/src/parse/tk_parse.c
+++ b/src/parse/tk_parse.c
@@ -150,7 +150,14 @@ pk_alloc(tk_parse_t *P, tk_ast_type_t type)
 {
     uint32_t idx;
 
-    if (P->n_node >= P->max_node) return 0;  /* sentinel */
+    if (P->n_node >= P->max_node) {
+        if (!P->node_ovf) {
+            P->node_ovf = 1;
+            P->n_err++;
+            tk_emsg(4, P->max_node);
+        }
+        return 0;                             /* sentinel */
+    }
 
     idx = P->n_node++;
     memset(&P->nodes[idx], 0, sizeof(tk_node_t));

--- a/src/parse/vh_parse.c
+++ b/src/parse/vh_parse.c
@@ -121,7 +121,14 @@ static uint32_t
 vp_alloc(tk_parse_t *P, tk_ast_type_t type)
 {
     uint32_t idx;
-    if (P->n_node >= P->max_node) return 0;
+    if (P->n_node >= P->max_node) {
+        if (!P->node_ovf) {
+            P->node_ovf = 1;
+            P->n_err++;
+            tk_emsg(4, P->max_node);
+        }
+        return 0;
+    }
     idx = P->n_node++;
     memset(&P->nodes[idx], 0, sizeof(tk_node_t));
     P->nodes[idx].type = type;

--- a/tests/tadv.c
+++ b/tests/tadv.c
@@ -1,0 +1,274 @@
+/* Copyright (c) 2026 Zane Hambly
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* tadv.c -- adversarial input
+ *
+ * Everything here asks the same question. When a bound is reached, does the
+ * tool say so, or does it hand back a smaller answer and call it a success?
+ *
+ * The pools are runtime fields as well as compile-time constants, so a test
+ * shrinks max_tok to eight rather than generating two megabytes of source to
+ * reach the real one. That is the only reason these paths had never been
+ * exercised. */
+
+#include "tharns.h"
+#include "takahe.h"
+
+/* Lex a string with the pools already tampered with by the caller. */
+static int
+ad_lex(const char *src, tk_lex_t *L)
+{
+    char *pp;
+    uint32_t pplen, slen;
+
+    slen = (uint32_t)strlen(src);
+    pp = (char *)malloc((size_t)slen * 2 + 256);
+    if (!pp) return -1;
+    tk_preproc(src, slen, pp, slen * 2 + 256, &pplen, NULL, 0);
+    tk_lex(L, pp, pplen);
+    free(pp);
+    return (int)L->n_tok;
+}
+
+/* ---- Token pool ----
+ * Past the limit the lexer used to return quietly, so the source truncated
+ * and the parser made what it could of the remains. */
+
+static void ad_tokp(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    L->max_tok = 8;
+    ad_lex("module m; wire a; wire b; wire c; wire d; endmodule", L);
+
+    CHECK(L->n_tok == 8);       /* filled it exactly, no overrun */
+    CHECK(L->tok_ovf == 1);     /* and noticed */
+    CHECK(L->n_err > 0);        /* and it reaches the exit status */
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_tokp)
+
+/* Reported once, however many tokens are left over. */
+static void ad_tok1(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    L->max_tok = 4;
+    ad_lex("module m; wire a; wire b; wire c; wire d; wire e; endmodule", L);
+
+    CHECK(L->n_err == 1);
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_tok1)
+
+/* ---- String pool ----
+ * Worse than truncation. lx_sint returns 0 when the pool is full and 0 is a
+ * real offset, so every later identifier aliases onto the first one interned
+ * and the netlist comes out plausible and wrong. */
+
+static void ad_strp(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    L->str_max = 24;
+    ad_lex("module alpha; wire bravo; wire charlie; endmodule", L);
+
+    CHECK(L->n_err > 0);
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_strp)
+
+/* Distinct identifiers must not collapse onto one another. */
+static void ad_alias(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    uint32_t i, first = 0;
+    int distinct = 0;
+
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    L->str_max = 24;
+    ad_lex("module alpha; wire bravo; wire charlie; endmodule", L);
+
+    for (i = 0; i < L->n_tok; i++)
+        if (L->tokens[i].type == TK_TOK_IDENT) {
+            if (distinct++ == 0) first = L->tokens[i].off;
+            else if (L->tokens[i].off != first) distinct = 99;
+        }
+
+    /* Either every identifier landed somewhere different, or the run failed.
+     * Silently pointing them all at offset 0 is the one outcome barred. */
+    CHECK(distinct == 99 || L->n_err > 0);
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_alias)
+
+/* ---- AST node pool ---- */
+
+static void ad_nodp(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    tk_parse_t *P = (tk_parse_t *)calloc(1, sizeof(tk_parse_t));
+    char *pp;
+    uint32_t pplen;
+    const char *src = "module m; wire a, b, c, d, e; "
+                      "assign a = b & c | d ^ e; endmodule";
+    uint32_t slen = (uint32_t)strlen(src);
+
+    CHECK(L && P);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    pp = (char *)malloc((size_t)slen * 2 + 256);
+    CHECK(pp != NULL);
+    tk_preproc(src, slen, pp, slen * 2 + 256, &pplen, NULL, 0);
+    tk_lex(L, pp, pplen);
+    free(pp);
+
+    tk_pinit(P, L);
+    P->max_node = 6;
+    tk_parse(P);
+
+    CHECK(P->n_node <= 6);      /* stayed inside the pool */
+    CHECK(P->n_err > 0);        /* and said the design did not fit */
+
+    tk_pfree(P); tk_ldfree(L);
+    free(P); free(L);
+    PASS();
+}
+TH_REG("adv", ad_nodp)
+
+/* ---- Guard sized in the wrong units ----
+ * The main lexer loop was bounded by TK_MAX_TOKENS while iterating over
+ * characters, so whitespace spent budget that produced no token. This source
+ * is mostly whitespace and longer than the old bound. Before the fix it
+ * stopped two thirds of the way through and returned success. */
+
+static void ad_guard(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    const uint32_t pad = 1200000;
+    char *src;
+    uint32_t i;
+
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    src = (char *)malloc(pad + 64);
+    CHECK(src != NULL);
+    for (i = 0; i < pad; i++) src[i] = (i % 40 == 39) ? '\n' : ' ';
+    memcpy(src + pad, "module tail; endmodule", 23);
+
+    ad_lex(src, L);
+    free(src);
+
+    /* The whole file, or an error. Not a quiet two thirds of it. */
+    CHECK(L->n_err == 0);
+    CHECK(L->n_tok >= 4);
+    CHECK(L->tokens[L->n_tok - 1].type == TK_TOK_EOF);
+    CHECK(L->tokens[L->n_tok - 1].line > 29000);
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_guard)
+
+/* ---- Rubbish in ----
+ * Bytes no SystemVerilog source would contain. Errors are the right answer,
+ * a hang or a crash is not. */
+
+static void ad_junk(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    char junk[512];
+    uint32_t i;
+
+    CHECK(L != NULL);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    /* Fixed pattern rather than random, so a failure reproduces. */
+    for (i = 0; i < sizeof junk - 1; i++)
+        junk[i] = (char)(1 + ((i * 37 + 11) % 254));
+    junk[sizeof junk - 1] = '\0';
+
+    ad_lex(junk, L);
+    CHECK(L->n_err > 0);
+
+    tk_ldfree(L); free(L);
+    PASS();
+}
+TH_REG("adv", ad_junk)
+
+/* Unterminated everything. Each of these ends mid-construct. */
+static void ad_trunc(void)
+{
+    static const char *cases[] = {
+        "module m;",
+        "module m; wire a = \"unterminated",
+        "/* unterminated comment",
+        "module m; assign a = (((((",
+        "`ifdef NOPE",
+        "module m; wire [",
+        ""
+    };
+    uint32_t i;
+
+    for (i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+        CHECK(L != NULL);
+        CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+        ad_lex(cases[i], L);          /* must return at all */
+        CHECK(L->n_tok <= L->max_tok);
+        tk_ldfree(L); free(L);
+    }
+    PASS();
+}
+TH_REG("adv", ad_trunc)
+
+/* Nesting deeper than anything sane, to prove the bound is a bound. */
+static void ad_deep(void)
+{
+    tk_lex_t *L = (tk_lex_t *)calloc(1, sizeof(tk_lex_t));
+    tk_parse_t *P = (tk_parse_t *)calloc(1, sizeof(tk_parse_t));
+    char *src;
+    uint32_t i, n = 2000;
+
+    CHECK(L && P);
+    CHECK(tk_ldinit(L, "defs/sv_tok.def") == 0);
+
+    src = (char *)malloc(n * 2 + 64);
+    CHECK(src != NULL);
+    memcpy(src, "module m; assign a = ", 21);
+    for (i = 0; i < n; i++) src[21 + i] = '(';
+    src[21 + n] = 'b';
+    for (i = 0; i < n; i++) src[22 + n + i] = ')';
+    memcpy(src + 22 + n + n, "; endmodule", 12);
+
+    ad_lex(src, L);
+    free(src);
+
+    tk_pinit(P, L);
+    tk_parse(P);                  /* must terminate, verdict is its own */
+    CHECK(P->n_node <= P->max_node);
+
+    tk_pfree(P); tk_ldfree(L);
+    free(P); free(L);
+    PASS();
+}
+TH_REG("adv", ad_deep)

--- a/tests/tmain.c
+++ b/tests/tmain.c
@@ -86,6 +86,7 @@ int main(int argc, char **argv)
         if (filter && strcmp(filter, th_list[i].tcats) != 0)
             continue;
 
+        int fbefore = nfail, sbefore = nskip;
         int before = npass + nfail + nskip;
         printf("  %-28s", th_list[i].tname);
         fflush(stdout);
@@ -94,11 +95,14 @@ int main(int argc, char **argv)
 
         int after = npass + nfail + nskip;
         if (after == before) {
-            /* Test didn't call PASS/FAIL/SKIP. Assume pass
-             * if it didn't crash — the silent majority. */
+            /* Asserted nothing and did not crash. Counted as a pass, which
+             * is generous, but a gutted test body is the caller's problem. */
             npass++;
         }
-        if (nfail == 0 || after > before)
+        /* Only when it actually passed. The old condition was true whenever
+         * any counter moved, so a failing test printed its FAIL line and then
+         * PASS underneath it. */
+        if (nfail == fbefore && nskip == sbefore)
             printf("PASS\n");
     }
 

--- a/tests/tmain.c
+++ b/tests/tmain.c
@@ -43,6 +43,12 @@ int th_run(const char *cmd, char *obuf, int osz)
     if (rc != -1 && (rc & 0xFF) == 0)
         rc = (rc >> 8) & 0xFF;
 #endif
+
+    /* Every caller wants zero, so a non-zero exit means the child said
+     * something. Printing it is how a sanitiser report reaches the log. */
+    if (rc != 0 && obuf[0] != '\0')
+        printf("\n--- exited %d: %s ---\n%s---\n", rc, cmd, obuf);
+
     return rc;
 }
 


### PR DESCRIPTION
Nine tests in tests/tadv.c that ask what happens when a pool fills rather than what happens in the middle. They found three things that were failing silently. All three lexers bounded the main loop with TK_MAX_TOKENS while iterating over characters, so a 2MB source truncated two thirds of the way through and still returned success. The token, string and AST pools all filled without saying anything. And sa_luby called itself with no stop condition on its reduction loop.

Turned out clang had never built the tree either, thanks to a gcc-only pragma, so there's a sanitiser job now that uses it. Fair warning, that job has never run anywhere, so this will be its first go.